### PR TITLE
Update mono_dataset.py

### DIFF
--- a/datasets/mono_dataset.py
+++ b/datasets/mono_dataset.py
@@ -173,7 +173,7 @@ class MonoDataset(data.Dataset):
             inputs[("inv_K", scale)] = torch.from_numpy(inv_K)
 
         if do_color_aug:
-            color_aug = transforms.ColorJitter.get_params(
+            color_aug = transforms.ColorJitter(
                 self.brightness, self.contrast, self.saturation, self.hue)
         else:
             color_aug = (lambda x: x)


### PR DESCRIPTION
transforms.ColorJitter.get_params returns tuple of parameters, which would cause error when preprocessing kitti dataset with the error 'tuple' not callable reported, while transforms.ColorJitter.forword returns image. Thus, the color_aug should be defined as transforms.ColorJitter(self.brightness, self.contrast, self.saturation, self.hue).